### PR TITLE
fix: remove unwanted dev warnings in production

### DIFF
--- a/source.lua
+++ b/source.lua
@@ -20,7 +20,7 @@ if global().mstudio45 and global().mstudio45.ESPLibrary then
 end
 
 local __DEBUG = false;
-local __LOG = global.environnement and global.environnement == "DEV" or false;
+local __LOG = global().environnement and global().environnement == "DEV" or false;
 local __PREFIX = "mstudio45's ESP"
 
 local Library = {

--- a/source.lua
+++ b/source.lua
@@ -20,7 +20,7 @@ if global().mstudio45 and global().mstudio45.ESPLibrary then
 end
 
 local __DEBUG = false;
-local __LOG = true;
+local __LOG = global.environnement and global.environnement == "DEV" or false;
 local __PREFIX = "mstudio45's ESP"
 
 local Library = {


### PR DESCRIPTION
users can however get logs by doing
```lua
getgenv().environnement = "DEV"
```